### PR TITLE
Added operator commands to transition system states

### DIFF
--- a/include/am_super/operator_command.h
+++ b/include/am_super/operator_command.h
@@ -1,0 +1,22 @@
+#ifndef AM_SUPER_INCLUDE_OPERATOR_COMMAND_H_
+#define AM_SUPER_INCLUDE_OPERATOR_COMMAND_H_
+
+#include <brain_box_msgs/OperatorCommand.h>
+
+
+/** Commands sent by the human operator to transition SuperStates through the standard flow.
+ * https://automodality.atlassian.net/wiki/spaces/AMROS/pages/929234949/AMROS+System+States
+ */
+enum class OperatorCommand : std::uint8_t
+{
+  ARM = brain_box_msgs::OperatorCommand::ARM,
+  LAUNCH = brain_box_msgs::OperatorCommand::LAUNCH,
+  PAUSE= brain_box_msgs::OperatorCommand::PAUSE,
+  RESUME=brain_box_msgs::OperatorCommand::RESUME,
+  MANUAL=brain_box_msgs::OperatorCommand::MANUAL,
+  LANDED=brain_box_msgs::OperatorCommand::LANDED,
+  ABORT=brain_box_msgs::OperatorCommand::ABORT,
+  SHUTDOWN=brain_box_msgs::OperatorCommand::SHUTDOWN,
+};
+
+#endif

--- a/include/am_super/operator_command.h
+++ b/include/am_super/operator_command.h
@@ -3,7 +3,6 @@
 
 #include <brain_box_msgs/OperatorCommand.h>
 
-
 /** Commands sent by the human operator to transition SuperStates through the standard flow.
  * https://automodality.atlassian.net/wiki/spaces/AMROS/pages/929234949/AMROS+System+States
  */

--- a/rostest/life_cycle_rostest.cpp
+++ b/rostest/life_cycle_rostest.cpp
@@ -30,10 +30,11 @@ constexpr int CHECK_TIME = 3;
 /* LifeCycle - indicates if we received the command yet for a nodde*/
 bool super_unconfigured = false;
 bool super_inactive = false; 
+bool super_active = false;
 
 bool rostest_unconfigured = false;
 bool rostest_inactive = false;
-
+bool rostest_active = false;
 
 
 constexpr string_view CORRECT = "CORRECT";  // represents the correct result in test
@@ -143,24 +144,37 @@ void nodeLifeCycleStateCallback(const brain_box_msgs::LifeCycleState& msg)
   ROS_INFO_STREAM("Node lifecycle state " << state_string << " received from " << msg.node_name);
   if(msg.node_name == "/am_super")
   {
-    if(state == LifeCycleState::UNCONFIGURED)
+    switch(state)
     {
-      super_unconfigured = true;
-    }
-    else if(state == LifeCycleState::INACTIVE)
-    {
-      super_inactive = true;
+      case LifeCycleState::UNCONFIGURED:
+        super_unconfigured = true;
+        break;
+      case LifeCycleState::INACTIVE:
+        super_inactive = true;
+        break;
+      case LifeCycleState::ACTIVE:
+        super_active = true;
+        break;
+      default:
+            ROS_WARN_STREAM("State not handled");      
     }
   }
   else
   {
-    if(state == LifeCycleState::UNCONFIGURED)
+     switch(state)
     {
-      rostest_unconfigured = true;
-    }
-    else if(state == LifeCycleState::INACTIVE)
-    {
-      rostest_inactive = true;
+      case LifeCycleState::UNCONFIGURED:
+        rostest_unconfigured = true;
+        break;
+      case LifeCycleState::INACTIVE:
+        rostest_inactive = true;
+        break;
+      case LifeCycleState::ACTIVE:
+        rostest_active = true;
+        break;
+      default:
+            ROS_WARN_STREAM("State not handled");
+
     }
   }
 }
@@ -181,26 +195,26 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
     ros::spinOnce();
     loop_rate.sleep();
   }
-  ASSERT_TRUE(booting) << "/am_super SuperState did not report a BOOTING state";
-  ASSERT_TRUE(super_unconfigured) << "/am_super LifeCycle did not report an UNCONFIGURED state"; 
-  ASSERT_TRUE(rostest_unconfigured) << "/life_cycle_rostest LifeCycle did not report an UNCONFIGURED state";
+  EXPECT_TRUE(booting) << "/am_super SuperState did not report a BOOTING state";
+  EXPECT_TRUE(super_unconfigured) << "/am_super LifeCycle did not report an UNCONFIGURED state"; 
+  EXPECT_TRUE(rostest_unconfigured) << "/life_cycle_rostest LifeCycle did not report an UNCONFIGURED state";
 
   ROS_INFO_STREAM("Waiting to receive READY from AMSuper (Ctrl-C to cancel)..\n");
 
   ready = super_inactive = rostest_inactive = false;
 
   EXPECT_FALSE(arming);
-  //FIXME: must add a circuit breaker to avoid infinite loop
   while ((!ready || !super_inactive || !rostest_inactive) && ros::ok())
   {
     ros::spinOnce();
     loop_rate.sleep();
   }
 
-  ASSERT_TRUE(ready) << "/am_super SuperState did not report a READY state";
-  ASSERT_TRUE(super_inactive) << "/am_super LifeCycle did not report an INACTIVE state"; 
-  ASSERT_TRUE(rostest_inactive) << "/life_cycle_rostest LifeCycle did not report an INACTIVE state";
-
+  EXPECT_TRUE(ready) << "/am_super SuperState did not report a READY state";
+  EXPECT_TRUE(super_inactive) << "/am_super LifeCycle did not report an INACTIVE state"; 
+  EXPECT_TRUE(rostest_inactive) << "/life_cycle_rostest LifeCycle did not report an INACTIVE state";
+  EXPECT_FALSE(super_active);
+  EXPECT_FALSE(rostest_active);
   ROS_INFO_STREAM("Ensure super remains in READY for atleast " << CHECK_TIME << " seconds:");
 
   {
@@ -217,7 +231,7 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
 
   EXPECT_FALSE(arming) << "ERROR: Super must wait for a trigger to transition to ARMING";
   EXPECT_FALSE(armed);
-  ASSERT_EQ(order_status, CORRECT) << order_status;
+  EXPECT_EQ(order_status, CORRECT) << order_status;
   EXPECT_TRUE(configured);
   EXPECT_FALSE(activated) << "ERROR: This node should not be activated yet";
   EXPECT_FALSE(cleanedUp);
@@ -240,7 +254,7 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
       cnt++;
       loop_rate.sleep();
     }    
-    ASSERT_TRUE(arming);
+    EXPECT_TRUE(arming);
   }
 
   //now it must go armed once all the nodes go active
@@ -252,10 +266,14 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
       cnt++;
       loop_rate.sleep();
     }    
-    ASSERT_TRUE(armed);
-    EXPECT_TRUE(activated) << "ERROR: This node should now be activated";
-
+    EXPECT_TRUE(armed);
+    EXPECT_TRUE(activated) << "ERROR: This node should now be";
+    EXPECT_TRUE(super_active);
+    EXPECT_TRUE(rostest_active);
   }
+
+
+
 
 }
 

--- a/rostest/life_cycle_rostest.cpp
+++ b/rostest/life_cycle_rostest.cpp
@@ -25,6 +25,7 @@ using namespace am;
 bool ready = false; 
 bool arming = false;
 bool booting = false;
+bool armed = false;
 constexpr int CHECK_TIME = 3;
 /* LifeCycle - indicates if we received the command yet for a nodde*/
 bool super_unconfigured = false;
@@ -127,6 +128,11 @@ void missionStateCallback(const brain_box_msgs::VxState& msg)
   {
     ROS_INFO_STREAM("ARMING received");
     arming = true;
+  }  
+  else if(msg.state == brain_box_msgs::VxState::ARMED)
+  {
+    ROS_INFO_STREAM("ARMED received");
+    armed = true;
   }
 }
 
@@ -183,6 +189,8 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
 
   ready = super_inactive = rostest_inactive = false;
 
+  EXPECT_FALSE(arming);
+  //FIXME: must add a circuit breaker to avoid infinite loop
   while ((!ready || !super_inactive || !rostest_inactive) && ros::ok())
   {
     ros::spinOnce();
@@ -196,6 +204,8 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
   ROS_INFO_STREAM("Ensure super remains in READY for atleast " << CHECK_TIME << " seconds:");
 
   {
+    EXPECT_FALSE(arming);
+    EXPECT_FALSE(armed);
     int cnt = 0;
     while(!arming && cnt < CHECK_TIME && ros::ok())
     {
@@ -206,7 +216,7 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
   }
 
   EXPECT_FALSE(arming) << "ERROR: Super must wait for a trigger to transition to ARMING";
-
+  EXPECT_FALSE(armed);
   ASSERT_EQ(order_status, CORRECT) << order_status;
   EXPECT_TRUE(configured);
   EXPECT_FALSE(activated) << "ERROR: This node should not be activated yet";
@@ -230,11 +240,23 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
       cnt++;
       loop_rate.sleep();
     }    
+    ASSERT_TRUE(arming);
   }
 
+  //now it must go armed once all the nodes go active
+  {
+    int cnt = 0;
+    while(!armed && cnt < CHECK_TIME && ros::ok())
+    {
+      ros::spinOnce();
+      cnt++;
+      loop_rate.sleep();
+    }    
+    ASSERT_TRUE(armed);
+    EXPECT_TRUE(activated) << "ERROR: This node should now be activated";
 
+  }
 
-  ASSERT_TRUE(arming);
 }
 
 int main(int argc, char** argv)

--- a/rostest/life_cycle_rostest.cpp
+++ b/rostest/life_cycle_rostest.cpp
@@ -14,6 +14,7 @@
 #include "ros/ros.h"                 // ros header file
 #include <gtest/gtest.h>             // googletest header file
 #include <brain_box_msgs/VxState.h>  // msg for status
+#include <brain_box_msgs/OperatorCommand.h>  // to be armed, launch for state transitions
 #include <super_lib/am_life_cycle.h>
 #include <super_lib/am_life_cycle_mediator.h>
 
@@ -24,7 +25,7 @@ bool ready = false; //indicates if we received READY from super
 bool arming = false;
 bool super_inactive = false; //indicates if we received the INACTIVE LC state from super
 
-constexpr int CHECK_TIME = 10;
+constexpr int CHECK_TIME = 3;
 
 constexpr string_view CORRECT = "CORRECT";  // represents the correct result in test
 string_view order_status = CORRECT;         // used in test to verify order_status is correct
@@ -136,6 +137,8 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
 
   ros::Subscriber missionStateSubscription = n.subscribe("/vstate/summary", 1000, missionStateCallback);
   ros::Subscriber nodeLifeCycleStateSubscription = n.subscribe("/node_state", 1000, nodeLifeCycleStateCallback);
+  //FIXME: reference constant for "/operator/command"
+  ros::Publisher operatorCommandPublisher = n.advertise<brain_box_msgs::OperatorCommand>("/operator/command",100);
   ros::Rate loop_rate(1);  // 1 Hz
 
   ROS_INFO_STREAM("Waiting to receive READY from AMSuper (Ctrl-C to cancel)..\n");
@@ -146,14 +149,16 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
   }
   ASSERT_TRUE(ready) << "Super did not report a READY state or ros::shutdown() was called";
   ASSERT_TRUE(super_inactive) << "Super LifeCycle did not report an INACTIVE state"; 
-  ROS_INFO_STREAM("Ensure super remains in READY for atleast 10 seconds:");
+  ROS_INFO_STREAM("Ensure super remains in READY for atleast " << CHECK_TIME << " seconds:");
 
-  int cnt = 0;
-  while(!arming && cnt < CHECK_TIME && ros::ok())
   {
-    ros::spinOnce();
-    cnt++;
-    loop_rate.sleep();
+    int cnt = 0;
+    while(!arming && cnt < CHECK_TIME && ros::ok())
+    {
+      ros::spinOnce();
+      cnt++;
+      loop_rate.sleep();
+    }
   }
 
   EXPECT_FALSE(arming) << "ERROR: Super must wait for a trigger to transition to ARMING";
@@ -166,6 +171,26 @@ TEST_F(LifeCycleNodeTest, testState_SuperRemainsInREADY)
   EXPECT_FALSE(destroyed);
   EXPECT_FALSE(errored);
   EXPECT_FALSE(shutdown);
+
+  // now, let's arm it
+  {
+    string node_name="/life_cycle_node_test";
+    brain_box_msgs::OperatorCommand armCommand;
+    armCommand.node_name = node_name;
+    armCommand.command = brain_box_msgs::OperatorCommand::ARM;
+    operatorCommandPublisher.publish(armCommand);
+    int cnt = 0;
+    while(!arming && cnt < CHECK_TIME && ros::ok())
+    {
+      ros::spinOnce();
+      cnt++;
+      loop_rate.sleep();
+    }    
+  }
+
+
+
+  ASSERT_TRUE(arming);
 }
 
 int main(int argc, char** argv)

--- a/src/am_super/am_super.cpp
+++ b/src/am_super/am_super.cpp
@@ -14,6 +14,7 @@
 #include <brain_box_msgs/BlinkMCommand.h>
 #include <brain_box_msgs/LifeCycleState.h>
 #include <brain_box_msgs/LogControl.h>
+#include <brain_box_msgs/OperatorCommand.h>
 #include <brain_box_msgs/StampedAltimeter.h>
 #include <brain_box_msgs/Super2Status.h>
 #include <brain_box_msgs/VxState.h>
@@ -61,6 +62,7 @@ private:
   ros::Publisher led_pub_;
   ros::Subscriber node_state_sub_;
   ros::Subscriber node_status_sub_;
+  ros::Subscriber operator_command_sub_;
   ros::Timer heartbeat_timer_;
 
   /** manage logic for SuperState transitions */
@@ -193,6 +195,8 @@ public:
      */
     node_status_sub_ = nh_.subscribe("/process/status", 100, &AMSuper::statusCB, this);
 
+    operator_command_sub_ = nh_.subscribe("/operator/command", 100, &AMSuper::operatorCommandCB, this);
+
     heartbeat_timer_ = nh_.createTimer(ros::Duration(1.0), &AMSuper::heartbeatCB, this);
   }
 
@@ -246,6 +250,18 @@ private:
     // TODO: topic name should come from vb_util_lib::topics.
     LOG_MSG("/process/status", rmsg, SU_LOG_LEVEL);
   }
+
+  void operatorCommandCB(const ros::MessageEvent<brain_box_msgs::OperatorCommand const>& event)
+  {
+    const brain_box_msgs::OperatorCommand::ConstPtr& rmsg = event.getMessage();
+    
+    ROS_INFO_STREAM(rmsg->node_name << " sent command " << rmsg->command );
+    supervisor_.operator_is_ready_to_arm = true;
+    // TODO: topic name should come from vb_util_lib::topics.
+    LOG_MSG("/operator/command", rmsg, SU_LOG_LEVEL);
+  }
+
+  
 
   /**
    * process state


### PR DESCRIPTION
Notice the arm command is sent by the test node to the super node which then signals it is arming. 

Question: Is the operator commands the way to go?  They were modeled directly after the state diagram actions between states.